### PR TITLE
Remove version number from zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build executable
         run: |
           pyinstaller Downloader.spec
-          Compress-Archive -Path dist\* -DestinationPath A32NX_Downloader_${{ github.event.release.tag_name }}.zip
+          Compress-Archive -Path dist\* -DestinationPath A32NX_Downloader.zip
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1
@@ -48,6 +48,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./A32NX_Downloader_${{ github.event.release.tag_name }}.zip
-          asset_name: A32NX_Downloader_${{ github.event.release.tag_name }}.zip
+          asset_path: ./A32NX_Downloader.zip
+          asset_name: A32NX_Downloader.zip
           asset_content_type: application/zip


### PR DESCRIPTION
I noticed you directly link the download to https://github.com/Externoak/A32NX-installer/releases/latest/download/A32NX_Downloader.zip in the readme. However, the release workflow also contains the version number in the filename so I removed that. So the zip file will always have the same name now.